### PR TITLE
Improve init.d script

### DIFF
--- a/system_files/improved/etc/default/portspoof
+++ b/system_files/improved/etc/default/portspoof
@@ -1,11 +1,13 @@
 #DAEMON=/usr/local/bin/portspoof
 #CONFIG=/usr/local/etc/portspoof.conf
 #SIGNATURES=/usr/local/etc/portspoof_signatures
-#PS_ARGUMENTS="-D -c $CONFIG -s $SIGNATURES"
 PS_UNFILTEREDPORTS="53 80 443 49152:65535"
 PS_INTERFACES="eth0"
 PS_LISTENPORT=4444
 #PS_USER=portspoof
+
+# WARNING: do not use the -D (daemon) option, as it will yield the wrong PID
+#PS_ARGUMENTS="-c $CONFIG -s $SIGNATURES"
 
 setup_custom_rules() {
   # Disable LAN spoofing

--- a/system_files/improved/etc/default/portspoof
+++ b/system_files/improved/etc/default/portspoof
@@ -4,7 +4,7 @@
 PS_UNFILTEREDPORTS="53 80 443 49152:65535"
 PS_INTERFACES="eth0"
 PS_LISTENPORT=4444
-#PS_USER=portspoof
+PS_USER=daemon
 
 # WARNING: do not use the -D (daemon) option, as it will yield the wrong PID
 #PS_ARGUMENTS="-c $CONFIG -s $SIGNATURES"

--- a/system_files/improved/etc/default/portspoof
+++ b/system_files/improved/etc/default/portspoof
@@ -1,6 +1,11 @@
+#DAEMON=/usr/local/bin/portspoof
+#CONFIG=/usr/local/etc/portspoof.conf
+#SIGNATURES=/usr/local/etc/portspoof_signatures
+#PS_ARGUMENTS="-D -c $CONFIG -s $SIGNATURES"
 PS_UNFILTEREDPORTS="53 80 443 49152:65535"
 PS_INTERFACES="eth0"
 PS_LISTENPORT=4444
+#PS_USER=portspoof
 
 setup_custom_rules() {
   # Disable LAN spoofing

--- a/system_files/improved/etc/default/portspoof
+++ b/system_files/improved/etc/default/portspoof
@@ -1,0 +1,8 @@
+PS_UNFILTEREDPORTS="53 80 443 49152:65535"
+PS_INTERFACES="eth0"
+PS_LISTENPORT=4444
+
+setup_custom_rules() {
+  # Disable LAN spoofing
+  #iptables -t nat -A PREPORTSPOOF -s 192.168.0.0/24 -j RETURN
+}

--- a/system_files/improved/etc/init.d/portspoof
+++ b/system_files/improved/etc/init.d/portspoof
@@ -76,7 +76,7 @@ setup_iptables() {
 get_pid() {
   if [ -e "$PIDFILE" ]; then
     [ ! -r "$PIDFILE" ] \
-      && log_warning_msg "Failed to lookup PID" "$PIDFILE" && exit 2
+      && log_failure_msg "Failed to read PIDFILE" "$PIDFILE" && exit 2
     echo $(cat "$PIDFILE")
   fi
 }
@@ -92,9 +92,9 @@ start)
       log_failure_msg "Failed to delete PIDFILE"
       exit 2
     fi
+    pid=
   fi
 
-  pid=$(get_pid)
   if [ ! -z "$pid" ]; then
     log_daemon_msg "portspoof is already running"
     exit 1

--- a/system_files/improved/etc/init.d/portspoof
+++ b/system_files/improved/etc/init.d/portspoof
@@ -144,7 +144,7 @@ start)
       pid="$!"
       echo "echo -n \"$pid\" > $PIDFILE" | sudo -s
     fi
-
+    sleep 2
     pid=$(get_pid)
     if [ ! -d "/proc/$pid" ]; then
       rm -f "$PIDFILE" 2> /dev/null

--- a/system_files/improved/etc/init.d/portspoof
+++ b/system_files/improved/etc/init.d/portspoof
@@ -19,11 +19,12 @@ DAEMON=/usr/local/bin/portspoof
 CONFIG=/usr/local/etc/portspoof.conf
 SIGNATURES=/usr/local/etc/portspoof_signatures
 
-PS_ARGUMENTS="-D -c $CONFIG -s $SIGNATURES"
 PS_UNFILTEREDPORTS="0:65535"
 PS_INTERFACES="eth0"
 PS_LISTENPORT=4444
 PS_USER=
+# WARNING: do not use the -D (daemon) option, as it will yield the wrong PID
+PS_ARGUMENTS="-c $CONFIG -s $SIGNATURES -p $PS_LISTENPORT"
 
 setup_custom_rules() { :; }
 
@@ -82,6 +83,17 @@ get_pid() {
 
 case "$1" in
 start)
+  # Ensure that the PIDFILE is still valid.
+  pid=$(get_pid)
+  if [ ! -d "/proc/$pid" ]; then
+    log_warning_msg "Invalid PID stored in PIDFILE"
+    rm -f "$PIDFILE" 2> /dev/null
+    if [ "$?" -ne 0 ]; then
+      log_failure_msg "Failed to delete PIDFILE"
+      exit 2
+    fi
+  fi
+
   pid=$(get_pid)
   if [ ! -z "$pid" ]; then
     log_daemon_msg "portspoof is already running"
@@ -100,7 +112,7 @@ start)
       exit 2
     fi
 
-    # Check if the supplied user exists
+    # Check whether the specified user exists
     user_exists=$(id -u "${PS_USER:-root}" &> /dev/null && echo $?)
     [ -z "$user_exists" ] \
       && log_failure_msg "User '${PS_USER:-root}' does not exist" && exit 2
@@ -117,15 +129,27 @@ start)
       && log_failure_msg "Can't read signatures file" "$SIGNATURES" && exit 2
 
     if [ -z "$PS_USER" ]; then
-      log_daemon_msg "Starting portspoof as root"
-      ($DAEMON $PS_ARGUMENTS &) > /dev/null &>&1
-      echo "echo -n \"$!\" > $PIDFILE" | sudo -s
+      log_daemon_msg "Starting portspoof"
+      #($DAEMON $PS_ARGUMENTS &) > /dev/null &>&1
+      nohup $DAEMON $PS_ARGUMENTS > /dev/null 2>&1 &
+      #$DAEMON $PS_ARGUMENTS &
+      pid="$!"
+      echo "echo -n \"$pid\" > $PIDFILE" | sudo -s
     else
       log_daemon_msg "Starting portspoof as ${PS_USER}"
-      (sudo -n -u "$PS_USER" $DAEMON $PS_ARGUMENTS &) > /dev/null &>&1
-      echo "echo -n \"$!\" > $PIDFILE" | sudo -s
+      #(sudo -n -u "$PS_USER" $DAEMON $PS_ARGUMENTS &) > /dev/null &>&1
+      nohup sudo -n -u "$PS_USER" $DAEMON $PS_ARGUMENTS > /dev/null 2>&1 &
+      #sudo -n -u "$PS_USER" $DAEMON $PS_ARGUMENTS &
+      pid="$!"
+      echo "echo -n \"$pid\" > $PIDFILE" | sudo -s
     fi
-    exit 0
+
+    pid=$(get_pid)
+    if [ ! -d "/proc/$pid" ]; then
+      rm -f "$PIDFILE" 2> /dev/null
+      log_failure_msg "Portspoof failed to start"
+      exit 2
+    fi
   fi
 ;;
 
@@ -133,11 +157,12 @@ stop)
   pid=$(get_pid)
   if [ ! -z "$pid" ]; then
     kill $pid
-    case "$?" in
+    retval=$?
+    rm -f "$PIDFILE" &> /dev/null
+    case "$retval" in
       0) log_daemon_msg "portspoof stopped" ;;
       *) log_failure_msg "Failed to stop portspoof"; exit 2 ;;
     esac
-    rm -f "$PIDFILE"
   else
     log_daemon_msg "portspoof not running"
   fi

--- a/system_files/improved/etc/init.d/portspoof
+++ b/system_files/improved/etc/init.d/portspoof
@@ -13,11 +13,26 @@
 # Description:       Start/stop Portspoof daemon
 ### END INIT INFO
 
-setup_iptables() {
-  # Allowed ports
-  unfilteredPorts="53 80 443 49152:65534"
-  interfaces="eth0"
+# Fallback configuration
+DAEMON=/usr/local/bin/portspoof
+CONFIG=/usr/local/etc/portspoof.conf
+SIGNATURES=/usr/local/etc/portspoof_signatures
 
+PS_UNFILTEREDPORTS="0:65535"
+PS_INTERFACES="eth0"
+PS_LISTENPORT=4444
+
+setup_custom_rules() { :; }
+
+# Exit if the daemon is not installed
+[ -x "$DAEMON" ] || exit 0
+
+. /lib/lsb/init-functions
+
+# Load variable configuration file if present
+[ -r /etc/default/portspoof ] && . /etc/default/portspoof
+
+setup_iptables() {
   iptables -t nat -N PREPORTSPOOF 2> /dev/null
   iptables -t nat -F PREPORTSPOOF
 
@@ -25,19 +40,18 @@ setup_iptables() {
   iptables -t nat -F PORTSPOOF
 
   iptables -t nat -A PORTSPOOF -p tcp -j LOG --log-prefix 'PORTSPOOF ' --log-level 4
-  iptables -t nat -A PORTSPOOF -p tcp -j REDIRECT --to-ports 4444
+  iptables -t nat -A PORTSPOOF -p tcp -j REDIRECT --to-ports ${PS_LISTENPORT}
   iptables -t nat -A PORTSPOOF -p udp -j LOG --log-prefix 'PORTSPOOF ' --log-level 4
-  iptables -t nat -A PORTSPOOF -p udp -j REDIRECT --to-ports 4444
+  iptables -t nat -A PORTSPOOF -p udp -j REDIRECT --to-ports ${PS_LISTENPORT}
 
-  # Disable LAN spoofing
-  #iptables -t nat -A PREPORTSPOOF -s 192.168.0.0/24 -j RETURN
+  setup_custom_rules
 
   rules=$(iptables -t nat -vnL PREROUTING --line-numbers|grep "/\* PORTSPOOF-REDIRECT \*/"|awk '{ print $1 }'|tac)
   for rule in ${rules}; do
     iptables -t nat -D PREROUTING ${rule}
   done
-  for int in ${interfaces}; do
-    for port in ${unfilteredPorts}; do
+  for int in ${PS_INTERFACES}; do
+    for port in ${PS_UNFILTEREDPORTS}; do
       iptables -t nat -A PREPORTSPOOF -i ${int} -p tcp -m tcp --dport ${port} -j RETURN
       iptables -t nat -A PREPORTSPOOF -i ${int} -p udp -m udp --dport ${port} -j RETURN
     done
@@ -53,30 +67,35 @@ case "$1" in
 start)
   if ! pidof portspoof > /dev/null; then
     count=$(iptables -t nat -N PREPORTSPOOF 2>&1|wc -l)
+
+    # This is pretty precarious, but should do the trick.
     if [ "$count" -eq 0 ]; then
+      log_daemon_msg "Setting up iptables rules"
       setup_iptables
     elif [ "$count" -eq 1 ]; then
-      echo "iptables rules already loaded, skipping."
+      log_daemon_msg "iptables rules already loaded, skipping"
     else
-      echo "Failed loading iptables rules."
+      log_failure_msg "Failed loading iptables rules"
     fi
-    echo "Starting Portspoof..."
-    /usr/local/bin/portspoof -D -c /usr/local/etc/portspoof.conf -s /usr/local/etc/portspoof_signatures
+
+    log_daemon_msg "Starting Portspoof" "portspoof"
+    $DAEMON -D -c $CONFIG -s $SIGNATURES
   else
-    echo "Portspoof already running."
+    log_daemon_msg "Portspoof already running."
   fi
 ;;
 
 stop)
   if pidof portspoof > /dev/null; then
     killall portspoof > /dev/null
-    echo "Portspoof stopped."
+    log_daemon_msg "Portspoof stopped"
   else
-    echo "Portspoof not running."
+    log_daemon_msg "Portspoof not running"
   fi
 ;;
 
 reload)
+  log_daemon_msg "Reloading iptables rules"
   setup_iptables
 ;;
 
@@ -86,6 +105,6 @@ restart)
 ;;
 
 *)
-  echo "Usage: $0 {start|stop|reload|restart}"
+  echo "Usage: $0 {start|stop|reload|restart}" >&2
   exit 1
 esac

--- a/system_files/improved/etc/init.d/portspoof
+++ b/system_files/improved/etc/init.d/portspoof
@@ -81,8 +81,7 @@ get_pid() {
   fi
 }
 
-case "$1" in
-start)
+do_start() {
   # Ensure that the PIDFILE is still valid.
   pid=$(get_pid)
   if [ ! -d "/proc/$pid" ]; then
@@ -116,18 +115,18 @@ start)
     # Check whether the specified user exists
     user_exists=$(id -u "${PS_USER:-root}" &> /dev/null && echo $?)
     [ -z "$user_exists" ] \
-      && log_failure_msg "User '${PS_USER:-root}' does not exist" && exit 2
+      && log_failure_msg "User '${PS_USER:-root}' does not exist" && exit 124
 
     # Check whether the user can execute the daemon
     has_permission=$(sh -c "sudo -n -u \"${PS_USER:-root}\" test -x $DAEMON && echo y" 2> /dev/null)
     [ -z "$has_permission" ] \
-      && log_failure_msg "User '${PS_USER}' cannot execute $DAEMON" && exit 2
+      && log_failure_msg "User '${PS_USER}' cannot execute $DAEMON" && exit 126
 
     # Check whether config files can be read
     [ ! -r "$CONFIG" ] \
-      && log_failure_msg "Can't read configuration file" "$CONFIG" && exit 2
+      && log_failure_msg "Can't read configuration file" "$CONFIG" && exit 126
     [ ! -r "$SIGNATURES" ] \
-      && log_failure_msg "Can't read signatures file" "$SIGNATURES" && exit 2
+      && log_failure_msg "Can't read signatures file" "$SIGNATURES" && exit 126
 
     if [ -z "$PS_USER" ]; then
       log_daemon_msg "Starting portspoof"
@@ -152,9 +151,9 @@ start)
       exit 2
     fi
   fi
-;;
+}
 
-stop)
+do_stop() {
   pid=$(get_pid)
   if [ ! -z "$pid" ]; then
     kill $pid
@@ -167,22 +166,28 @@ stop)
   else
     log_daemon_msg "portspoof not running"
   fi
-;;
+}
 
-reload)
+do_reload() {
   log_daemon_msg "Reloading iptables rules"
   setup_iptables
-;;
+}
 
-restart)
-  $0 stop
-  $0 start
-;;
+do_restart() {
+  do_stop
+  [ "$?" -eq 0 ] && do_start
+}
 
+case "$1" in
+start) do_start ;;
+stop) do_stop ;;
+reload) do_reload ;;
+restart) do_restart ;;
 status)
-  status_of_proc -p "${PIDFILE}" $DAEMON portspoof
+  retval=0
+  status_of_proc -p "${PIDFILE}" $DAEMON portspoof || retval=$?
+  exit $retval
 ;;
-
 *)
   log_action_msg "Usage: $0 {start|stop|reload|restart|status}"
   exit 1

--- a/system_files/improved/etc/init.d/portspoof
+++ b/system_files/improved/etc/init.d/portspoof
@@ -9,18 +9,21 @@
 # Should-Stop:       $network $syslog iptables
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Start/stop Portspoof daemon
-# Description:       Start/stop Portspoof daemon
+# Short-Description: Start/stop portspoof daemon
+# Description:       Start/stop portspoof daemon
 ### END INIT INFO
 
 # Fallback configuration
+PIDFILE=/var/run/portspoof.pid
 DAEMON=/usr/local/bin/portspoof
 CONFIG=/usr/local/etc/portspoof.conf
 SIGNATURES=/usr/local/etc/portspoof_signatures
 
+PS_ARGUMENTS="-D -c $CONFIG -s $SIGNATURES"
 PS_UNFILTEREDPORTS="0:65535"
 PS_INTERFACES="eth0"
 PS_LISTENPORT=4444
+PS_USER=
 
 setup_custom_rules() { :; }
 
@@ -31,6 +34,10 @@ setup_custom_rules() { :; }
 
 # Load variable configuration file if present
 [ -r /etc/default/portspoof ] && . /etc/default/portspoof
+
+get_prerouting_rule() {
+  echo $(iptables -t nat -vnL PREROUTING --line-numbers 2> /dev/null | grep "/\* PORTSPOOF-REDIRECT \*/" | awk '{ print $1 }' | head -1)
+}
 
 setup_iptables() {
   iptables -t nat -N PREPORTSPOOF 2> /dev/null
@@ -46,10 +53,12 @@ setup_iptables() {
 
   setup_custom_rules
 
-  rules=$(iptables -t nat -vnL PREROUTING --line-numbers|grep "/\* PORTSPOOF-REDIRECT \*/"|awk '{ print $1 }'|tac)
-  for rule in ${rules}; do
+  rule=$(get_prerouting_rule)
+  while [ ! -z "$rule" ]; do
     iptables -t nat -D PREROUTING ${rule}
+    rule=$(get_prerouting_rule)
   done
+
   for int in ${PS_INTERFACES}; do
     for port in ${PS_UNFILTEREDPORTS}; do
       iptables -t nat -A PREPORTSPOOF -i ${int} -p tcp -m tcp --dport ${port} -j RETURN
@@ -63,12 +72,24 @@ setup_iptables() {
   done
 }
 
+get_pid() {
+  if [ -e "$PIDFILE" ]; then
+    [ ! -r "$PIDFILE" ] \
+      && log_warning_msg "Failed to lookup PID" "$PIDFILE" && exit 2
+    echo $(cat "$PIDFILE")
+  fi
+}
+
 case "$1" in
 start)
-  if ! pidof portspoof > /dev/null; then
-    count=$(iptables -t nat -N PREPORTSPOOF 2>&1|wc -l)
+  pid=$(get_pid)
+  if [ ! -z "$pid" ]; then
+    log_daemon_msg "portspoof is already running"
+    exit 1
+  else
+    count=$(iptables -t nat -N PREPORTSPOOF 2>&1 | wc -l)
 
-    # This is pretty precarious, but should do the trick.
+    # This is rather precarious, but should do the trick.
     if [ "$count" -eq 0 ]; then
       log_daemon_msg "Setting up iptables rules"
       setup_iptables
@@ -76,21 +97,49 @@ start)
       log_daemon_msg "iptables rules already loaded, skipping"
     else
       log_failure_msg "Failed loading iptables rules"
+      exit 2
     fi
 
-    log_daemon_msg "Starting Portspoof" "portspoof"
-    $DAEMON -D -c $CONFIG -s $SIGNATURES
-  else
-    log_daemon_msg "Portspoof already running."
+    # Check if the supplied user exists
+    user_exists=$(id -u "${PS_USER:-root}" &> /dev/null && echo $?)
+    [ -z "$user_exists" ] \
+      && log_failure_msg "User '${PS_USER:-root}' does not exist" && exit 2
+
+    # Check whether the user can execute the daemon
+    has_permission=$(sh -c "sudo -n -u \"${PS_USER:-root}\" test -x $DAEMON && echo y" 2> /dev/null)
+    [ -z "$has_permission" ] \
+      && log_failure_msg "User '${PS_USER}' cannot execute $DAEMON" && exit 2
+
+    # Check whether config files can be read
+    [ ! -r "$CONFIG" ] \
+      && log_failure_msg "Can't read configuration file" "$CONFIG" && exit 2
+    [ ! -r "$SIGNATURES" ] \
+      && log_failure_msg "Can't read signatures file" "$SIGNATURES" && exit 2
+
+    if [ -z "$PS_USER" ]; then
+      log_daemon_msg "Starting portspoof as root"
+      ($DAEMON $PS_ARGUMENTS &) > /dev/null &>&1
+      echo "echo -n \"$!\" > $PIDFILE" | sudo -s
+    else
+      log_daemon_msg "Starting portspoof as ${PS_USER}"
+      (sudo -n -u "$PS_USER" $DAEMON $PS_ARGUMENTS &) > /dev/null &>&1
+      echo "echo -n \"$!\" > $PIDFILE" | sudo -s
+    fi
+    exit 0
   fi
 ;;
 
 stop)
-  if pidof portspoof > /dev/null; then
-    killall portspoof > /dev/null
-    log_daemon_msg "Portspoof stopped"
+  pid=$(get_pid)
+  if [ ! -z "$pid" ]; then
+    kill $pid
+    case "$?" in
+      0) log_daemon_msg "portspoof stopped" ;;
+      *) log_failure_msg "Failed to stop portspoof"; exit 2 ;;
+    esac
+    rm -f "$PIDFILE"
   else
-    log_daemon_msg "Portspoof not running"
+    log_daemon_msg "portspoof not running"
   fi
 ;;
 
@@ -104,7 +153,11 @@ restart)
   $0 start
 ;;
 
+status)
+  status_of_proc -p "${PIDFILE}" $DAEMON portspoof
+;;
+
 *)
-  echo "Usage: $0 {start|stop|reload|restart}" >&2
+  log_action_msg "Usage: $0 {start|stop|reload|restart|status}"
   exit 1
 esac

--- a/system_files/improved/etc/init.d/portspoof
+++ b/system_files/improved/etc/init.d/portspoof
@@ -99,18 +99,19 @@ start)
     log_daemon_msg "portspoof is already running"
     exit 1
   else
-    count=$(iptables -t nat -N PREPORTSPOOF 2>&1 | wc -l)
-
-    # This is rather precarious, but should do the trick.
-    if [ "$count" -eq 0 ]; then
-      log_daemon_msg "Setting up iptables rules"
-      setup_iptables
-    elif [ "$count" -eq 1 ]; then
-      log_daemon_msg "iptables rules already loaded, skipping"
-    else
-      log_failure_msg "Failed loading iptables rules"
-      exit 2
-    fi
+    # Setup iptables rules
+    iptables -t nat -N PREPORTSPOOF 2> /dev/null
+    case "$?" in
+      0)
+        log_daemon_msg "Setting up iptables rules"
+        setup_iptables
+      ;;
+      1) log_daemon_msg "iptables rules already loaded, skipping" ;;
+      *)
+        log_failure_msg "Failed loading iptables rules; check your permissions"
+        exit 3
+      ;;
+    esac
 
     # Check whether the specified user exists
     user_exists=$(id -u "${PS_USER:-root}" &> /dev/null && echo $?)

--- a/system_files/init.d/portspoof_improved.sh
+++ b/system_files/init.d/portspoof_improved.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Starts and stops Portspoof daemon
+
+setup_iptables() {
+  # Allowed ports
+  unfilteredPorts="53 80 443 49152:65534"
+  interfaces="eth0"
+
+  iptables -t nat -N PREPORTSPOOF 2> /dev/null
+  iptables -t nat -F PREPORTSPOOF
+
+  iptables -t nat -N PORTSPOOF 2> /dev/null
+  iptables -t nat -F PORTSPOOF
+
+  iptables -t nat -A PORTSPOOF -p tcp -j LOG --log-prefix 'PORTSPOOF ' --log-level 4
+  iptables -t nat -A PORTSPOOF -p tcp -j REDIRECT --to-ports 4444
+  iptables -t nat -A PORTSPOOF -p udp -j LOG --log-prefix 'PORTSPOOF ' --log-level 4
+  iptables -t nat -A PORTSPOOF -p udp -j REDIRECT --to-ports 4444
+
+  # Disable LAN spoofing
+  #iptables -t nat -A PREPORTSPOOF -s 192.168.0.0/24 -j RETURN
+
+  rules=$(iptables -t nat -vnL PREROUTING --line-numbers|grep "/\* PORTSPOOF-REDIRECT \*/"|awk '{ print $1 }'|tac)
+  for rule in ${rules}; do
+    iptables -t nat -D PREROUTING ${rule}
+  done
+  for int in ${interfaces}; do
+    for port in ${unfilteredPorts}; do
+      iptables -t nat -A PREPORTSPOOF -i ${int} -p tcp -m tcp --dport ${port} -j RETURN
+      iptables -t nat -A PREPORTSPOOF -i ${int} -p udp -m udp --dport ${port} -j RETURN
+    done
+
+    iptables -t nat -A PREPORTSPOOF -p tcp -m tcp -i ${int} -j PORTSPOOF
+    iptables -t nat -A PREPORTSPOOF -p udp -m udp -i ${int} -j PORTSPOOF
+
+    iptables -t nat -A PREROUTING -i ${int} -j PREPORTSPOOF -m comment --comment "PORTSPOOF-REDIRECT"
+  done
+}
+
+case "$1" in
+start)
+  if ! pidof portspoof > /dev/null; then
+    count=$(iptables -t nat -N PREPORTSPOOF 2>&1|wc -l)
+    if [ "$count" -eq 0 ]; then
+      setup_iptables
+    elif [ "$count" -eq 1 ]; then
+      echo "iptables rules already loaded, skipping."
+    else
+      echo "Failed loading iptables rules."
+    fi
+    echo "Starting Portspoof..."
+    /usr/local/bin/portspoof -D -c /usr/local/etc/portspoof.conf -s /usr/local/etc/portspoof_signatures
+  else
+    echo "Portspoof already running."
+  fi
+;;
+
+stop)
+  if pidof portspoof > /dev/null; then
+    killall portspoof > /dev/null
+    echo "Portspoof stopped."
+  else
+    echo "Portspoof not running."
+  fi
+;;
+
+reload)
+  setup_iptables
+;;
+
+restart)
+  $0 stop
+  $0 start
+;;
+
+*)
+  echo "Usage: $0 {start|stop|reload|restart}"
+  exit 1
+esac

--- a/system_files/init.d/portspoof_improved.sh
+++ b/system_files/init.d/portspoof_improved.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
-# Starts and stops Portspoof daemon
+# Startup script for the Portspoof daemon using iptables
+#
+### BEGIN INIT INFO
+# Provides:          portspoof
+# Required-Start:    $local_fs
+# Required-Stop:     $local_fs
+# Should-Start:      $network $syslog iptables
+# Should-Stop:       $network $syslog iptables
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start/stop Portspoof daemon
+# Description:       Start/stop Portspoof daemon
+### END INIT INFO
 
 setup_iptables() {
   # Allowed ports


### PR DESCRIPTION
~~I made some tweaks to the~~ I rewrote the `init.d` script, so that port-spoofing exceptions can be added on a whitelist basis. I also ensured that the loading and reapplying of `iptables` rules is as painless as possible (i.e. rules appended in default chains are comment-tagged so that they can be easily filtered).